### PR TITLE
Increase move column min width to make it fit two digit move numbers

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -1,5 +1,5 @@
 $grid-side-column: fit-content(40%) !default;
-$grid-side-column-full-screen: minmax(200px, 1fr) !default;
+$grid-side-column-full-screen: minmax(232px, 1fr) !default;
 $grid-side-row: 6em !default;
 $player-height: 2em !default;
 $controls-height: 4em !default;


### PR DESCRIPTION
Otherwise they wrap: https://lichess.org/forum/lichess-feedback/game-declares-draw-even-though-it-is-mate-in-1