### PR TITLE
Add menu configuration options for analysis board, computer practice

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,12 @@ const defaults: Opts = {
       enabled: true, // enable the "Get PGN" menu entry
       fileName: undefined, // name of the file when user clicks "Download PGN". Leave empty for automatic name.
     },
+    practiceWithComputer: {
+      enabled: true,
+    },
+    analysisBoard: {
+      enabled: true,
+    }
   },
   lichess: 'https://lichess.org', // support for Lichess games, with links to the game and players. Set to false to disable.
   classes: undefined, // CSS classes to set on the root element. Defaults to the element classes before being replaced by LPV.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -93,6 +93,12 @@ export interface Opts {
       enabled?: boolean;
       fileName?: string;
     };
+    practiceWithComputer?: {
+      enabled?: boolean;
+    };
+    analysisBoard?: {
+      enabled?: boolean;
+    }
   };
   lichess: Lichess;
   classes?: string;

--- a/src/view/menu.ts
+++ b/src/view/menu.ts
@@ -13,26 +13,30 @@ export const renderMenu = (ctrl: PgnViewer) =>
       },
       ctrl.translate('flipTheBoard')
     ),
-    h(
-      'a.lpv__menu__entry.lpv__menu__analysis.lpv__fbt',
-      {
-        attrs: {
-          href: ctrl.analysisUrl(),
-          target: '_blank',
-        },
-      },
-      ctrl.translate('analysisBoard')
-    ),
-    h(
-      'a.lpv__menu__entry.lpv__menu__practice.lpv__fbt',
-      {
-        attrs: {
-          href: ctrl.practiceUrl(),
-          target: '_blank',
-        },
-      },
-      ctrl.translate('practiceWithComputer')
-    ),
+    ctrl.opts.menu.analysisBoard?.enabled
+      ? h(
+          'a.lpv__menu__entry.lpv__menu__analysis.lpv__fbt',
+          {
+            attrs: {
+              href: ctrl.analysisUrl(),
+              target: '_blank',
+            },
+          },
+          ctrl.translate('analysisBoard')
+        )
+      : undefined,
+    ctrl.opts.menu.practiceWithComputer?.enabled
+      ? h(
+          'a.lpv__menu__entry.lpv__menu__practice.lpv__fbt',
+          {
+            attrs: {
+              href: ctrl.practiceUrl(),
+              target: '_blank',
+            },
+          },
+          ctrl.translate('practiceWithComputer')
+        )
+      : undefined,
     ctrl.opts.menu.getPgn.enabled
       ? h(
           'button.lpv__menu__entry.lpv__menu__pgn.lpv__fbt',


### PR DESCRIPTION
This commit adds a couple of new configuration options for the conditional display of the "Practice with computer" and "Analysis board" options.

Since the defaults are set to `true` there shouldn't be any change for current users.

The motivation for this is I'm using the board to display in-progress daily/correspondence games.