### PR TITLE
WIP: Add custom event for path changes

### DIFF
--- a/src/pgnViewer.ts
+++ b/src/pgnViewer.ts
@@ -46,6 +46,7 @@ export default class PgnViewer {
   canGoTo = (to: GoTo) => (to == 'prev' || to == 'first' ? !this.path.empty() : !!this.curNode().children[0]);
 
   toPath = (path: Path, focus = true) => {
+    this.div?.dispatchEvent(new CustomEvent('pathChange', { detail: { path: path } }));
     this.path = path;
     this.pane = 'board';
     this.autoScrollRequested = true;


### PR DESCRIPTION
This PR adds a custom event that fires any time the path changes.

I'm not sure if this is the kind of thing you want to have in the codebase so I thought I would start this PR as a kind of discussion.

For the thing I'm working on I thought it would be interesting to be able to view a game from both players' perspectives at the same time. For this to be useful would require the two boards to be in sync. Having a simple custom event like this allows me to achieve that with a simple event listener:

```js
    pgnViewer.div.addEventListener('pathChange', (event) => {
      reversedViewer.toPath(event.detail.path)
    })
```
https://github.com/lichess-org/pgn-viewer/assets/8656640/4fc22a46-36b4-4d49-9c48-aa96a7ccfb17

At first I tried to do this by adding click event listeners to the back/forward arrows, but that doesn't account for keyboard nav or clicking on moves in the list, and they also got cleared out after opening the menu since I think the buttons get re-rendered.

Anyway, if this seems like an ok idea to you, I was thinking it might be best to include some kind of abstraction around it, especially since there are one or two other things I might like to keep track of (like board size).