### PR TITLE
Fix scrollbar color for light mode

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -189,3 +189,23 @@ You can find the book here for an absurdly low price: https://www.amazon.com/Mam
 ].forEach((cfg, i) =>
   LichessPgnViewer(document.querySelector(`.viewers > div:nth-child(${i + 1}) > div`), cfg),
 );
+
+const lightColors = {
+  "--c-lpv-accent": "hsl(209, 77%, 46%)",
+  "--c-lpv-bg": "--c-lpv-bg",
+  "--c-lpv-bg-player": "--c-lpv-bg",
+  "--c-lpv-bg-controls": "--c-lpv-bg",
+  "--c-lpv-bg-movelist":  "--c-lpv-bg",
+  "--c-lpv-bg-variation": "hsl(37, 12%, 92%)",
+  "--c-lpv-pgn-text": "hsl(37, 12%, 92%)",
+  "--c-lpv-font": "color(srgb 0.3019 0.302 0.302)",
+  "--c-lpv-font-bg": "color(srgb 0.8392 0.8392 0.8393)",
+  "--demo-bg": 'color(srgb 0.9272 0.9173 0.9047)'
+}
+
+document.getElementById('light-mode-selector').addEventListener('change', (e) => {
+  Object.entries(lightColors).forEach(([key, color],_) => {
+    console.log(key, color);
+    document.documentElement.style.setProperty(key, e.target.checked ? color : "unset");
+  })});
+

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,7 @@
     <title>Lichess PGN Viewer</title>
   </head>
   <body>
+    <input type="checkbox" id="light-mode-selector"> <label for="checkbox" style="color: #aaa">Light mode</label>
     <div class="viewers">
       <div><div></div></div>
       <div><div class="previous-class"></div></div>

--- a/demo/lichess-pgn-viewer.demo.css
+++ b/demo/lichess-pgn-viewer.demo.css
@@ -1,5 +1,5 @@
 body {
-  background: #161512;
+  background: var(--demo-bg, #161512);
   font-family: 'Noto Sans';
   --board-color: #886f46;
   margin: 0;

--- a/scss/_scrollbar.scss
+++ b/scss/_scrollbar.scss
@@ -1,14 +1,16 @@
-body ::-webkit-scrollbar,
-body ::-webkit-scrollbar-corner {
-  width: 0.5rem;
-  background: $lpv-bg;
-}
+.lpv {
+  *::-webkit-scrollbar,
+  *::-webkit-scrollbar-corner {
+    width: 0.5rem;
+    background: var(--c-lpv-bg, $lpv-bg);
+  }
 
-body ::-webkit-scrollbar-thumb {
-  background: var(--c-lpv-font-bg, $lpv-font-bg);
-}
+  *::-webkit-scrollbar-thumb {
+    background: var(--c-lpv-font-bg, $lpv-font-bg);
+  }
 
-body ::-webkit-scrollbar-thumb:hover,
-body ::-webkit-scrollbar-thumb:active {
-  background: $lpv-font-shy;
+  *::-webkit-scrollbar-thumb:hover,
+  *::-webkit-scrollbar-thumb:active {
+    background: var(--c-lpv-font-shy, $lpv-font-shy);
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ const defaults: Opts = {
     },
     analysisBoard: {
       enabled: true,
-    }
+    },
   },
   lichess: 'https://lichess.org', // support for Lichess games, with links to the game and players. Set to false to disable.
   classes: undefined, // CSS classes to set on the root element. Defaults to the element classes before being replaced by LPV.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -98,7 +98,7 @@ export interface Opts {
     };
     analysisBoard?: {
       enabled?: boolean;
-    }
+    };
   };
   lichess: Lichess;
   classes?: string;


### PR DESCRIPTION
The scrollbar styling was applied to the whole body, and the css-variable override was missing, resulting in bad scrollbar in light mode:
![Screenshot 2024-07-03 at 20 23 52](https://github.com/lichess-org/pgn-viewer/assets/56031107/1f4a30b8-55fd-48e8-865a-a190a7bc392e)

after
![Screenshot 2024-07-03 at 20 23 32](https://github.com/lichess-org/pgn-viewer/assets/56031107/6b547096-e5ac-493e-8415-0ca5bbfdfbeb)

these screenshots were taken from Lila instance with the updated repo synced locally, but for convenience I've added a built-in light mode with some colors in demo.js, to easily try things out. I've not put all colors since I didn't need them.
![Screenshot 2024-07-03 at 20 26 53](https://github.com/lichess-org/pgn-viewer/assets/56031107/c9138ec6-b6e7-40a5-ae63-25af45d6895f)
