### PR TITLE
Fix moves not showing when showMoves=bottom or =auto with mobile portrait screen

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -5,6 +5,7 @@ $player-height: 2em !default;
 $controls-height: 4em !default;
 $moves-auto-to-right: 500px !default;
 $board-min-width: 200px !default;
+$moves-height: 14em !default;
 
 .lpv {
   display: grid;
@@ -12,6 +13,7 @@ $board-min-width: 200px !default;
   grid-row-gap: 0;
 
   --controls-height: #{$controls-height};
+
   &--controls-false {
     --controls-height: 0em;
   }
@@ -37,7 +39,8 @@ $board-min-width: 200px !default;
       'board'
       'controls'
       'side';
-    grid-template-rows: auto var(--controls-height);
+    grid-template-rows: auto var(--controls-height) $moves-height;
+
     .lpv__controls {
       border-bottom: 1px solid var(--c-lpv-border, $lpv-border);
     }
@@ -49,16 +52,15 @@ $board-min-width: 200px !default;
       'controls   side';
     grid-template-columns: minmax($board-min-width, calc(100vh - var(--controls-height))) $grid-side-column-full-screen;
     grid-template-rows: auto var(--controls-height);
+
     @media (max-width: #{$moves-auto-to-right}) {
       grid-template-areas:
         'board'
         'controls'
         'side';
-      grid-template-columns: minmax(
-        $board-min-width,
-        calc(100vh - var(--controls-height) - #{$grid-side-row})
-      );
-      grid-template-rows: auto var(--controls-height);
+      grid-template-columns: minmax($board-min-width,
+        calc(100vh - var(--controls-height) - #{$grid-side-row}));
+      grid-template-rows: auto var(--controls-height) $moves-height;
     }
   }
 
@@ -88,7 +90,8 @@ $board-min-width: 200px !default;
         'player-bot'
         'controls'
         'side';
-      grid-template-rows: $player-height auto $player-height var(--controls-height);
+      grid-template-rows: $player-height auto $player-height var(--controls-height) $moves-height;
+
       .lpv__controls {
         border-bottom: 1px solid var(--c-lpv-border, $lpv-border);
       }
@@ -100,10 +103,9 @@ $board-min-width: 200px !default;
         'board      side'
         'player-bot side'
         'controls   side';
-      grid-template-columns:
-        minmax($board-min-width, calc(100vh - 2 * #{$player-height} - var(--controls-height)))
-        $grid-side-column-full-screen;
+      grid-template-columns: minmax($board-min-width, calc(100vh - 2 * #{$player-height} - var(--controls-height))) $grid-side-column-full-screen;
       grid-template-rows: $player-height auto $player-height var(--controls-height);
+
       @media (max-width: #{$moves-auto-to-right}) {
         grid-template-areas:
           'player-top'
@@ -111,11 +113,9 @@ $board-min-width: 200px !default;
           'player-bot'
           'controls'
           'side';
-        grid-template-columns: minmax(
-          $board-min-width,
-          calc(100vh - 2 * #{$player-height} - var(--controls-height) - #{$grid-side-row})
-        );
-        grid-template-rows: $player-height auto $player-height var(--controls-height);
+        grid-template-columns: minmax($board-min-width,
+          calc(100vh - 2 * #{$player-height} - var(--controls-height) - #{$grid-side-row}));
+        grid-template-rows: $player-height auto $player-height var(--controls-height) $moves-height;
       }
     }
   }
@@ -123,21 +123,27 @@ $board-min-width: 200px !default;
   &__board {
     grid-area: board;
   }
+
   &__side {
     grid-area: side;
   }
+
   &__player--top {
     grid-area: player-top;
   }
+
   &__player--bottom {
     grid-area: player-bot;
   }
+
   &__controls {
     grid-area: controls;
   }
+
   &__menu,
   &__pgn {
     grid-area: 1 / 1 / 2 / 2;
+
     .lpv--players & {
       grid-area: 1 / 1 / 4 / 2;
     }


### PR DESCRIPTION
Fix for #28 , moves were never visible on mobile.

Height of  moves grid row was not defined in scss , so  when showMoves=bottom or showMoves=auto and the screen was small portrait, as in mobile, moves where not visible. 