### PR TITLE
Remove grid template areas on 450px breakpoint

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -52,10 +52,6 @@ $board-min-width: 200px !default;
       $grid-side-column-full-screen;
     grid-template-rows: auto var(--controls-height);
     @media (max-width: #{$moves-auto-to-right}) {
-      grid-template-areas:
-        'board'
-        'controls'
-        'side';
       grid-template-columns: minmax(
         $board-min-width,
         calc(100vh - var(--controls-height) - #{$grid-side-row})


### PR DESCRIPTION
This takes care of https://github.com/lichess-org/lila/issues/16977 by removing the `grid-template-areas` property at the `@media (max-width: #{$moves-auto-to-right})` breakpoint. This means that the move list will always be shown on the rightmost part of the widget no matter how small the viewport.

I'm unsure whether or not keeping the move list always present at the right is the desired behavior since commit https://github.com/lichess-org/pgn-viewer/commit/9358ea1086ae2a03de799bea5564c6d8129aeba8 appears to tackle cases where the widget is presented a single column grid.