### PR TITLE
revert snabbdom version rev

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
     "@types/node": "^22.13.4",
     "chessground": "^9.1.1",
     "chessops": "^0.14.2",
-    "snabbdom": "^3.6.2"
+    "snabbdom": "^3.5.1"
   },
+  "//": [
+    "snabbdom pinned to 3.5.1 until https://github.com/snabbdom/snabbdom/issues/1114 is resolved"
+  ],
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.24.1",
     "@typescript-eslint/parser": "^8.24.1",


### PR DESCRIPTION
we use 3.5.1 in lila due to the insane type checking overhead they introduced for jsx. i recommend backing pgn-viewer's snab down to 3.5.1 as well (for optimal code splitting in lila).