### PR TITLE
Fix pnpm run dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "declaration": true,
     "sourceMap": true,
     "outDir": "dist",
-    "rootDir": "src",
     "target": "ES2019",
     "module": "esnext",
     "lib": ["DOM", "ES2019"]


### PR DESCRIPTION
Revert partially commit e601b65eb7e77461f3bc9f5c514d05b6889a4656.

The commit message of the reverted commit seems to be incorrect. Running `pnpm run dist` only produces `lichess-pgn-viewer.css` and `lichess-pgn-viewer.min.js`. By removing, the line `"rootDir": "src"`, it is now generating again `dist/interface.d.ts`.