### PR TITLE
update workflows actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
-          node-version: 24.1.0
+          node-version: 24
           cache: pnpm
       - run: pnpm install
       - run: pnpm lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -46,7 +46,7 @@ jobs:
           pnpm publish --provenance --access public
           git push origin HEAD --follow-tags
 
-      - name: Publish to github
+      - name: Publish to GitHub
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.version }}


### PR DESCRIPTION
# Why

There were no warnings in CI runs (since workflows were configured to use Node 24 already), but it does not hurt to use latest action versions anyway.

# How

Bump all used workflow actions to the latest version, unpin Node version in CI workflows, so latest release from 24 major is used.