### PR TITLE
Fix narrow embedded movetext layout

### DIFF
--- a/scss/_layout.scss
+++ b/scss/_layout.scss
@@ -3,7 +3,7 @@ $grid-side-column-full-screen: minmax(232px, 1fr) !default;
 $grid-side-row: 6em !default;
 $player-height: 2em !default;
 $controls-height: 4em !default;
-$moves-auto-to-right: 450px !default;
+$moves-auto-to-right: 500px !default;
 $board-min-width: 200px !default;
 
 .lpv {
@@ -56,11 +56,15 @@ $board-min-width: 200px !default;
         'board'
         'controls'
         'side';
-      grid-template-columns: minmax(
-        $board-min-width,
-        calc(100vh - var(--controls-height) - #{$grid-side-row})
-      );
-      grid-template-rows: auto var(--controls-height);
+      grid-template-columns: minmax($board-min-width, 100%);
+      grid-template-rows: auto var(--controls-height) $grid-side-row;
+      .lpv__board,
+      .lpv__controls {
+        width: clamp($board-min-width, calc(100vh - var(--controls-height) - #{$grid-side-row}), 100%);
+      }
+      .lpv__side {
+        width: 100%;
+      }
     }
   }
 
@@ -113,11 +117,20 @@ $board-min-width: 200px !default;
           'player-bot'
           'controls'
           'side';
-        grid-template-columns: minmax(
-          $board-min-width,
-          calc(100vh - 2 * #{$player-height} - var(--controls-height) - #{$grid-side-row})
-        );
+        grid-template-columns: minmax($board-min-width, 100%);
         grid-template-rows: $player-height auto $player-height var(--controls-height) $grid-side-row;
+        .lpv__player,
+        .lpv__board,
+        .lpv__controls {
+          width: clamp(
+            $board-min-width,
+            calc(100vh - 2 * #{$player-height} - var(--controls-height) - #{$grid-side-row}),
+            100%
+          );
+        }
+        .lpv__side {
+          width: 100%;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes lichess-org/lila#16977.
Refs #28.

Follow-up to lichess-org/lila#20773, where @ornicar pointed out that this layout fix belongs in the LPV package rather than lila's theme layer.

## What changed

- Stack `showMoves: "auto"` layouts up to 500px, matching the lila-side fix that was redirected here.
- In the stacked auto-moves layout, make the grid column use the full embed width.
- Keep the board, players, and controls constrained by the existing viewport-height budget, while letting the movetext side panel use the full embed width.

## Proof

Generated against compiled pgn-viewer CSS at a 360px-high mobile viewport for 500, 480, 451, 450, 420, and 360px embed widths.

![players 420px comparison](https://raw.githubusercontent.com/markoub/pgn-viewer/proof-lpv-narrow-layout/comparison-players-420.png)

Key players-layout measurements:

```text
500px: before side=252px, cols=248px 252px | after side=500px, cols=500px
480px: before side=232px, cols=248px 232px | after side=480px, cols=480px
451px: before side=232px, cols=219px 232px | after side=451px, cols=451px
450px: before side=200px, cols=200px     | after side=450px, cols=450px
420px: before side=200px, cols=200px     | after side=420px, cols=420px
360px: before side=200px, cols=200px     | after side=360px, cols=360px
```

Additional proof:

- [simple 500px comparison](https://raw.githubusercontent.com/markoub/pgn-viewer/proof-lpv-narrow-layout/comparison-simple-500.png)
- [players 500px comparison](https://raw.githubusercontent.com/markoub/pgn-viewer/proof-lpv-narrow-layout/comparison-players-500.png)
- [full measurements JSON](https://raw.githubusercontent.com/markoub/pgn-viewer/proof-lpv-narrow-layout/measurements.json)

## Validation

- `pnpm install`
- `pnpm run sass-dev` (passes; existing Sass deprecation warnings only)
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run compile`
- `pnpm test`
- `git diff --check origin/master...HEAD`

## AI assistance disclosure

I used OpenAI Codex to inspect the lila follow-up request, port the Sass layout change into pgn-viewer, run local validation, and generate the before/after proof artifacts. I reviewed the final diff and can explain each line.
