### PR TITLE
inherit background color from move type when active

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -227,6 +227,8 @@ const lightColors = {
   '--c-lpv-bg-controls': '--c-lpv-bg',
   '--c-lpv-bg-movelist': '--c-lpv-bg',
   '--c-lpv-bg-variation': 'hsl(37, 12%, 92%)',
+  '--c-lpv-border': 'hsl(0, 0%, 75%)',
+  '--c-lpv-side-border': 'var(--c-lpv-border)',
   '--c-lpv-pgn-text': 'hsl(37, 12%, 92%)',
   '--c-lpv-font': 'color(srgb 0.3019 0.302 0.302)',
   '--c-lpv-font-bg': 'color(srgb 0.8392 0.8392 0.8393)',

--- a/scss/_lichess-pgn-viewer.lib.scss
+++ b/scss/_lichess-pgn-viewer.lib.scss
@@ -34,6 +34,12 @@ $lpv-bg-blunder-hover: mix($lpv-blunder, $lpv-bg, 30%) !default;
 $lpv-bg-good-hover: mix($lpv-good-move, $lpv-bg, 30%) !default;
 $lpv-bg-brilliant-hover: mix($lpv-brilliant, $lpv-bg, 30%) !default;
 $lpv-bg-interesting-hover: mix($lpv-interesting, $lpv-bg, 30%) !default;
+$lpv-bg-inaccuracy-current: mix($lpv-inaccuracy, $lpv-bg, 50%) !default;
+$lpv-bg-mistake-current: mix($lpv-mistake, $lpv-bg, 50%) !default;
+$lpv-bg-blunder-current: mix($lpv-blunder, $lpv-bg, 50%) !default;
+$lpv-bg-good-current: mix($lpv-good-move, $lpv-bg, 50%) !default;
+$lpv-bg-brilliant-current: mix($lpv-brilliant, $lpv-bg, 50%) !default;
+$lpv-bg-interesting-current: mix($lpv-interesting, $lpv-bg, 50%) !default;
 
 @import './fbt';
 @import './util';

--- a/scss/_side.scss
+++ b/scss/_side.scss
@@ -52,42 +52,72 @@
         color: var(--c-lpv-past-moves, $lpv-past-moves);
       }
       &.current {
-        background: var(--c-lpv-current-move, $lpv-current-move) !important;
+        background: var(--c-lpv-current-move, $lpv-current-move);
         color: var(--c-lpv-accent-over, $lpv-accent-over);
       }
       &.inaccuracy {
         color: var(--c-lpv-inaccuracy, $lpv-inaccuracy);
-        &:hover {
+        &.current {
+          background: var(--c-lpv-bg-inaccuracy-current, $lpv-bg-inaccuracy-current);
+          color: var(--c-lpv-accent-over, $lpv-accent-over);
+        }
+        &:hover,
+        &.current:hover {
           background: var(--c-lpv-bg-inaccuracy-hover, $lpv-bg-inaccuracy-hover);
         }
       }
       &.mistake {
         color: var(--c-lpv-mistake, $lpv-mistake);
-        &:hover {
+        &.current {
+          background: var(--c-lpv-bg-mistake-current, $lpv-bg-mistake-current);
+          color: var(--c-lpv-accent-over, $lpv-accent-over);
+        }
+        &:hover,
+        &.current:hover {
           background: var(--c-lpv-bg-mistake-hover, $lpv-bg-mistake-hover);
         }
       }
       &.blunder {
         color: var(--c-lpv-blunder, $lpv-blunder);
-        &:hover {
+        &.current {
+          background: var(--c-lpv-bg-blunder-current, $lpv-bg-blunder-current);
+          color: var(--c-lpv-accent-over, $lpv-accent-over);
+        }
+        &:hover,
+        &.current:hover {
           background: var(--c-lpv-bg-blunder-hover, $lpv-bg-blunder-hover);
         }
       }
       &.good {
         color: var(--c-lpv-good-move, $lpv-good-move);
-        &:hover {
+        &.current {
+          background: var(--c-lpv-bg-good-current, $lpv-bg-good-current);
+          color: var(--c-lpv-accent-over, $lpv-accent-over);
+        }
+        &:hover,
+        &.current:hover {
           background: var(--c-lpv-bg-good-hover, $lpv-bg-good-hover);
         }
       }
       &.brilliant {
         color: var(--c-lpv-brilliant, $lpv-brilliant);
-        &:hover {
+        &.current {
+          background: var(--c-lpv-bg-brilliant-current, $lpv-bg-brilliant-current);
+          color: var(--c-lpv-accent-over, $lpv-accent-over);
+        }
+        &:hover,
+        &.current:hover {
           background: var(--c-lpv-bg-brilliant-hover, $lpv-bg-brilliant-hover);
         }
       }
       &.interesting {
         color: var(--c-lpv-interesting, $lpv-interesting);
-        &:hover {
+        &.current {
+          background: var(--c-lpv-bg-interesting-current, $lpv-bg-interesting-current);
+          color: var(--c-lpv-accent-over, $lpv-accent-over);
+        }
+        &:hover,
+        &.current:hover {
           background: var(--c-lpv-bg-interesting-hover, $lpv-bg-interesting-hover);
         }
       }


### PR DESCRIPTION
# Why

Spotted that currently `.current` background color takes a precedence which causes a bit unreadable color combinations in some cases.

<img width="472" height="268" alt="Screenshot 2026-07-25 at 11 45 36" src="https://github.com/user-attachments/assets/44027011-e76f-4ff6-a49e-f0e35b1fc436" />
<img width="481" height="177" alt="Screenshot 2026-07-25 at 11 50 10" src="https://github.com/user-attachments/assets/d1c7bc60-4c9d-40e7-9c0a-ca044facc6df" />


# How

Inherit background color from move type when active and use selected font color to improve contrast.

Additionally, I have made a small fix for demo light mode, to address incorrectly styled borders.

# Preview

<img width="634" height="525" alt="Screenshot 2026-07-25 at 11 41 32" src="https://github.com/user-attachments/assets/4b5a122a-3010-41b1-8734-a8a2f61da84b" />
<img width="632" height="534" alt="Screenshot 2026-07-25 at 11 48 08" src="https://github.com/user-attachments/assets/91ec30f2-4799-4067-aaff-3ba55609e6ba" />
<img width="634" height="525" alt="Screenshot 2026-07-25 at 11 41 40" src="https://github.com/user-attachments/assets/64b78924-36c0-421c-9468-8d8ffd48342f" />
<img width="634" height="525" alt="Screenshot 2026-07-25 at 11 42 11" src="https://github.com/user-attachments/assets/a73c9663-e7a8-47fb-86c2-53a75d0b4b37" />
